### PR TITLE
🛡️ Sentinel: [MEDIUM] Remove dangerouslySetInnerHTML

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-01 - [Remove dangerouslySetInnerHTML]
+**Vulnerability:** Found `dangerouslySetInnerHTML` injecting raw CSS into the App component.
+**Learning:** Even if the input is hardcoded CSS and not immediately exploitable for XSS, using `dangerouslySetInnerHTML` creates a poor security pattern. It opens the door for future developers to inadvertently inject dynamic, un-sanitized variables.
+**Prevention:** Avoid `dangerouslySetInnerHTML` unless absolutely necessary (e.g. rendering trusted rich text). Extract CSS to global stylesheet (`index.css`) for better maintainability and security.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -376,26 +376,6 @@ export default function App() {
         </div>
       </footer>
 
-      {/* Custom Scrollbar Styles */}
-      <style dangerouslySetInnerHTML={{__html: `
-        .custom-scrollbar::-webkit-scrollbar {
-          width: 6px;
-        }
-        .custom-scrollbar::-webkit-scrollbar-track {
-          background: rgba(24, 24, 27, 0.5);
-          border-radius: 4px;
-        }
-        .custom-scrollbar::-webkit-scrollbar-thumb {
-          background: rgba(82, 82, 91, 0.5);
-          border-radius: 4px;
-        }
-        .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-          background: rgba(113, 113, 122, 0.8);
-        }
-        @keyframes shimmer {
-          100% { transform: translateX(100%); }
-        }
-      `}} />
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,20 @@
 @import "tailwindcss";
+
+/* Custom Scrollbar Styles */
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: rgba(24, 24, 27, 0.5);
+  border-radius: 4px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(82, 82, 91, 0.5);
+  border-radius: 4px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgba(113, 113, 122, 0.8);
+}
+@keyframes shimmer {
+  100% { transform: translateX(100%); }
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Found `dangerouslySetInnerHTML` injecting raw CSS into the App component. While not an immediate XSS vulnerability due to the static content, it poses a long-term risk.
🎯 Impact: Using `dangerouslySetInnerHTML` is generally an anti-pattern unless absolutely necessary for rendering dynamic rich text. By keeping it, future developers could inadvertently inject un-sanitized, dynamic variables which could then lead to a Cross-Site Scripting (XSS) vulnerability.
🔧 Fix: Extracted the hardcoded CSS custom scrollbar styles and the keyframe animation and moved them directly to `src/index.css`. Removed the `<style dangerouslySetInnerHTML />` block entirely from `src/App.tsx`.
✅ Verification: Successfully verified changes by building (`npm run build`), running TS lint checks (`npm run lint`), and visual inspection via Playwright screenshot. Added a learning log to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3285167538241649901](https://jules.google.com/task/3285167538241649901) started by @ochowei*