### PR TITLE
[Done T-002] 新增 Ending 介面定義

### DIFF
--- a/docs/TASK_LIST.md
+++ b/docs/TASK_LIST.md
@@ -1,3 +1,3 @@
 任務 ID,關聯目標,任務描述 (Commit Scope),執行者,狀態
 T-001,G-001,新增 src/types/game.ts 定義五大境界的資料結構,Coder-Bot,done
-T-002,G-001,在 src/types/ending.ts 定義 Ending 相關資料結構 (interface: Ending)，需包含 id: string、name: string、description: string 與 triggerCondition 條件判斷，以支援 64 種結局,Coder-Bot,waiting
+T-002,G-001,在 src/types/ending.ts 定義 Ending 相關資料結構 (interface: Ending)，需包含 id: string、name: string、description: string 與 triggerCondition 條件判斷，以支援 64 種結局,Coder-Bot,done

--- a/src/types/ending.ts
+++ b/src/types/ending.ts
@@ -1,0 +1,19 @@
+export interface Ending {
+  /** 結局的唯一識別碼，支援 64 種結局的分類 */
+  id: string;
+
+  /** 結局名稱，例如「飛升仙界」、「走火入魔」 */
+  name: string;
+
+  /** 結局的詳細描述，解釋達成此結局的背景與結果 */
+  description: string;
+
+  /**
+   * 觸發條件判斷函式
+   * 用於在遊戲結束或特定事件時，動態判斷玩家是否滿足該結局條件。
+   *
+   * @param gameState 傳入目前的遊戲狀態（例如屬性、境界、事件標記等）
+   * @returns boolean 若滿足條件則回傳 true，否則回傳 false
+   */
+  triggerCondition: (gameState: any) => boolean;
+}


### PR DESCRIPTION
This pull request addresses task T-002 from the `docs/TASK_LIST.md` document.
It creates the `Ending` interface in `src/types/ending.ts` to support the 64-ending system for the cultivation game.

- Created `src/types/ending.ts`.
- Defined `id`, `name`, `description`, and `triggerCondition` properties.
- Included comprehensive documentation comments.
- Updated the status of task `T-002` to `done` in `docs/TASK_LIST.md`.

---
*PR created automatically by Jules for task [16561733923006976681](https://jules.google.com/task/16561733923006976681) started by @ochowei*