### PR TITLE
feat(save): add save data migration logic

### DIFF
--- a/docs/PROJECT_LOG.md
+++ b/docs/PROJECT_LOG.md
@@ -1,3 +1,5 @@
 - [2024-03-01] (PM-Alpha) 分配新任務 T-002: 定義 Ending 相關資料結構 (src/types/ending.ts) 以支援 64 種結局的目標 (G-001)。
 - [2024-03-01] (Coder-Bot) 開始執行 T-003：在 src/types/game.ts 新增 SaveVersion 欄位（number 型別）並在 App.tsx 的 INITIAL_STATE 加入預設值 1
 - [2024-03-01] (Coder-Bot) 完成 T-003 [Done]：在 GameState 加入 saveVersion 欄位並更新 INITIAL_STATE 的型別
+[2024-03-01] (Coder-Bot) 開始執行 T-004：新增 src/utils/save.ts 檔案，並實作 migrateSaveData(data: any) 與 migrateV1toV2 函式以進行存檔版本遷移（確保舊存檔可升級），並設定為匯出
+[2024-03-01] (Coder-Bot) 完成 T-004 [Done]：新增 migrateSaveData 存檔遷移函式

--- a/docs/TASK_LIST.md
+++ b/docs/TASK_LIST.md
@@ -2,4 +2,4 @@
 T-001,G-001,—,新增 src/types/game.ts 定義五大境界的資料結構,Coder-Bot,done
 T-002,G-001,—,在 src/types/ending.ts 定義 Ending 相關資料結構 (interface: Ending)，需包含 id: string、name: string、description: string 與 triggerCondition 條件判斷，以支援 64 種結局,Coder-Bot,done
 T-003,G-001,T-080,在 src/types/game.ts 新增 SaveVersion 欄位（number 型別）並在 App.tsx 的 INITIAL_STATE 加入預設值 1,Coder-Bot,done
-T-004,G-001,T-080,新增 src/utils/save.ts 檔案，並實作 migrateSaveData(data: any) 與 migrateV1toV2 函式以進行存檔版本遷移（確保舊存檔可升級），並設定為匯出,Coder-Bot,waiting
+T-004,G-001,T-080,新增 src/utils/save.ts 檔案，並實作 migrateSaveData(data: any) 與 migrateV1toV2 函式以進行存檔版本遷移（確保舊存檔可升級），並設定為匯出,Coder-Bot,done

--- a/src/utils/save.ts
+++ b/src/utils/save.ts
@@ -1,0 +1,19 @@
+export function migrateV1toV2(data: unknown): unknown {
+  if (typeof data !== 'object' || data === null) return data;
+  return {
+    ...data,
+    saveVersion: 2,
+  };
+}
+
+export function migrateSaveData(data: unknown): unknown {
+  if (typeof data !== 'object' || data === null) return data;
+
+  let migratedData = { ...data } as Record<string, unknown>;
+
+  if (typeof migratedData.saveVersion !== 'number' || migratedData.saveVersion < 2) {
+    migratedData = migrateV1toV2(migratedData) as Record<string, unknown>;
+  }
+
+  return migratedData;
+}


### PR DESCRIPTION
實作 `migrateV1toV2` 和 `migrateSaveData`，在不引入 `any` 型別的情況下，支援舊存檔向 saveVersion 2 遷移。

---
*PR created automatically by Jules for task [17783742389845098187](https://jules.google.com/task/17783742389845098187) started by @ochowei*