### PR TITLE
feat(save): apply migrateSaveData to localStorage parsed JSON

### DIFF
--- a/docs/PROJECT_LOG.md
+++ b/docs/PROJECT_LOG.md
@@ -4,3 +4,5 @@
 [2024-03-01] (Coder-Bot) 開始執行 T-004：新增 src/utils/save.ts 檔案，並實作 migrateSaveData(data: any) 與 migrateV1toV2 函式以進行存檔版本遷移（確保舊存檔可升級），並設定為匯出
 [2024-03-01] (Coder-Bot) 完成 T-004 [Done]：新增 migrateSaveData 存檔遷移函式
 - [2026-03-02] (PM-Alpha) 指派 T-005（關聯 設計任務T-080 的第 3 步）給 Coder-Bot。
+[2026-03-02] (Coder-Bot) 開始執行 T-005：在 src/App.tsx 引入 migrateSaveData 函式，並於 useState 初始化讀取 localStorage 存檔時，對解析出的 JSON 資料套用 migrateSaveData 進行舊格式遷移
+[2026-03-02] (Coder-Bot) 完成 T-005 [Done]：在 App.tsx 引入並套用 migrateSaveData 進行舊格式遷移

--- a/docs/TASK_LIST.md
+++ b/docs/TASK_LIST.md
@@ -3,4 +3,4 @@ T-001,G-001,—,新增 src/types/game.ts 定義五大境界的資料結構,Coder
 T-002,G-001,—,在 src/types/ending.ts 定義 Ending 相關資料結構 (interface: Ending)，需包含 id: string、name: string、description: string 與 triggerCondition 條件判斷，以支援 64 種結局,Coder-Bot,done
 T-003,G-001,T-080,在 src/types/game.ts 新增 SaveVersion 欄位（number 型別）並在 App.tsx 的 INITIAL_STATE 加入預設值 1,Coder-Bot,done
 T-004,G-001,T-080,新增 src/utils/save.ts 檔案，並實作 migrateSaveData(data: any) 與 migrateV1toV2 函式以進行存檔版本遷移（確保舊存檔可升級），並設定為匯出,Coder-Bot,done
-T-005,G-001,T-080,在 src/App.tsx 引入 migrateSaveData 函式，並於 useState 初始化讀取 localStorage 存檔時，對解析出的 JSON 資料套用 migrateSaveData 進行舊格式遷移,Coder-Bot,waiting
+T-005,G-001,T-080,在 src/App.tsx 引入 migrateSaveData 函式，並於 useState 初始化讀取 localStorage 存檔時，對解析出的 JSON 資料套用 migrateSaveData 進行舊格式遷移,Coder-Bot,done

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Zap, ArrowUpCircle, ScrollText, Pickaxe, RotateCcw } from 'lucide-react';
 import type { Realm, GameState, Facility } from './types/game';
+import { migrateSaveData } from './utils/save';
 
 // --- Constants & Data ---
 const REALMS: Realm[] = [
@@ -78,12 +79,13 @@ export default function App() {
     if (saved) {
       try {
         const parsed = JSON.parse(saved);
+        const migrated = migrateSaveData(parsed) as Partial<GameState>;
         // 合併初始狀態以處理未來可能新增的設施
         return { 
           ...INITIAL_STATE, 
-          ...parsed, 
+          ...migrated,
           facilities: INITIAL_STATE.facilities.map(f => {
-            const savedF = parsed.facilities?.find((sf: any) => sf.id === f.id);
+            const savedF = migrated.facilities?.find((sf: any) => sf.id === f.id);
             return savedF ? { ...f, level: savedF.level } : f;
           }) 
         };


### PR DESCRIPTION
完成 T-005 任務，在 src/App.tsx 引入 migrateSaveData 函式，並於 useState 初始化讀取 localStorage 存檔時，對解析出的 JSON 資料套用 migrateSaveData 進行舊格式遷移。並依規定更新了 TASK_LIST.md 和 PROJECT_LOG.md 的紀錄。

---
*PR created automatically by Jules for task [13280246509205203277](https://jules.google.com/task/13280246509205203277) started by @ochowei*