### PR TITLE
fix: restore correct Jules API source format in pm-alpha-scheduler

### DIFF
--- a/.github/workflows/pm-alpha-scheduler.yml
+++ b/.github/workflows/pm-alpha-scheduler.yml
@@ -106,7 +106,7 @@ jobs:
           # 這樣可以確保換行符號被正確跳脫，符合 JSON 規格
           jq -n \
             --arg prompt "$PROMPT" \
-            --arg source "ochowei/idle-game-2026-1" \
+            --arg source "sources/github-ochowei-idle-game-2026-1" \
             --arg branch "main" \
             '{
               prompt: $prompt,


### PR DESCRIPTION
The source field was incorrectly changed from 'sources/github-ochowei-idle-game-2026-1' to 'ochowei/idle-game-2026-1', causing a 400 INVALID_ARGUMENT error. The Jules API requires the format 'sources/github-{owner}-{repo}'.

https://claude.ai/code/session_01R68X3QPVpctGuSH7gYmdvf