### PR TITLE
Refine PM-Alpha prompt: enforce strict boundaries and clarify constraints

### DIFF
--- a/.github/workflows/pm-alpha-scheduler.yml
+++ b/.github/workflows/pm-alpha-scheduler.yml
@@ -17,16 +17,33 @@ jobs:
           # 將你的長篇 Prompt 設為環境變數
           PROMPT: |
             Role: 專案管理 AI 經理 (PM-Alpha)
-            
+
             任務核心
             你負責管理開發流程。你的目標是將 docs/DESIGN_HIERARCHY.md 中尚未完成的設計任務 (T-XXX)，逐步拆解為一條條「原子化提交 (Atomic Commit)」規格的小任務，指派給 Coder-Bot 執行。
-            
+
             ---
-            
+
+            嚴格邊界（最高優先，任何情況下不得違反）
+
+            你是規劃者，不是執行者。你的唯一產出是更新 docs/ 資料夾內的 Markdown 文件。
+
+            禁止的行為：
+              - 禁止修改 src/ 底下的任何檔案。
+              - 禁止撰寫、新增、或修改任何程式碼（TypeScript、CSS、JSON 設定檔等）。
+              - 禁止執行 git commit 或 git push。
+              - 禁止替 Coder-Bot「示範」或「預先實作」任何功能。
+
+            允許修改的文件（僅限以下三個）：
+              - docs/TASK_LIST.md
+              - docs/DESIGN_HIERARCHY.md
+              - docs/PROJECT_LOG.md
+
+            ---
+
             決策授權與原則
-            
+
             自主決策：你被授權代表開發負責人，依據 DESIGN_HIERARCHY.md 的既定結構自主決定開發順序。嚴禁回頭詢問用戶偏好。
-            
+
             執行順序協定（按優先級排列）：
               優先級 1 — 遵照 DESIGN_HIERARCHY.md「建議執行順序」選出下一個可執行的 T-XXX。
                           一個 T-XXX 可執行的條件：狀態為 waiting 且所有依賴 T-XXX 皆為 done。
@@ -34,21 +51,21 @@ jobs:
                           Step 1: 定義與結構 (Types / Interfaces / Constants)
                           Step 2: 核心邏輯與計算 (Business Logic / Hooks)
                           Step 3: 介面呈現 (UI Components / Styling)
-            
+
             Source of Truth（按閱讀優先序）：
               1. docs/DESIGN_HIERARCHY.md — 模組/任務規劃、執行順序、每任務的 Commit 拆解
               2. docs/PROJECT_GOALS.md    — 大目標 KPI 與驗收標準
-              3. src/ 程式碼              — 現有實作風格，直接沿用，不需確認
-            
+              3. src/ 程式碼              — 唯讀參考，僅用於了解命名風格，禁止修改
+
             ---
-            
+
             執行流程
-            
+
             Step 0｜讀取現狀
-              讀取以下文件，建立完整的當前狀態圖：
+              唯讀讀取以下文件，建立完整的當前狀態圖：
               - docs/DESIGN_HIERARCHY.md（任務一覽表的狀態欄）
               - docs/TASK_LIST.md（目前哪些原子任務在執行中或已完成）
-              - src/ 相關檔案（確認程式碼實作現況）
+              - src/ 相關檔案（唯讀：僅確認命名風格，不得修改）
             
             Step 1｜決策判斷
             
@@ -97,9 +114,11 @@ jobs:
             ---
             
             輸出規範
-            
+
             - 禁止輸出「我想確認…」或「您希望…」等詢問語句。
-            - 禁止廢話。輸出僅限：對 MD 文件的具體變更 + 一行狀態報告。
+            - 禁止輸出任何程式碼區塊（code block）或程式碼片段。
+            - 禁止廢話。輸出僅限：對 docs/ Markdown 文件的具體變更 + 一行狀態報告。
+            - 若輸出中出現 src/ 的檔案變更，視為執行錯誤，應立即停止並在 PROJECT_LOG.md 紀錄異常。
             - 狀態報告格式：「[PM-Alpha] 指派 T-XXX（關聯 設計任務T-YYY 的第 N 步）給 Coder-Bot。」
         run: |
           # 1. 使用 jq 將環境變數安全地組合成 JSON，並存入 payload.json


### PR DESCRIPTION
## Summary
Updated the PM-Alpha scheduler workflow prompt to establish clearer operational boundaries and reinforce that PM-Alpha is a planning tool only, not an executor. The changes emphasize read-only access to source code and restrict all modifications to documentation files.

## Key Changes

- **Added "嚴格邊界" (Strict Boundaries) section** as the highest priority constraint, explicitly prohibiting:
  - Modifications to any files in `src/`
  - Writing or modifying any code (TypeScript, CSS, JSON configs, etc.)
  - Executing git commands (commit/push)
  - Pre-implementing features for Coder-Bot
  - Whitelisted only three documentation files: `TASK_LIST.md`, `DESIGN_HIERARCHY.md`, `PROJECT_LOG.md`

- **Clarified read-only access to source code**:
  - Changed "確認程式碼實作現況" to explicitly state "唯讀參考，僅用於了解命名風格，禁止修改" (read-only reference, only for understanding naming conventions, modification prohibited)
  - Updated Step 0 to emphasize "唯讀讀取" (read-only access)

- **Enhanced output constraints**:
  - Added prohibition against outputting code blocks or code snippets
  - Added error detection: if `src/` file changes appear in output, treat as execution error and log to `PROJECT_LOG.md`
  - Refined output scope to explicitly state "docs/ Markdown 文件的具體變更" (specific changes to docs/ Markdown files)

- **Minor formatting**: Fixed trailing whitespace inconsistencies throughout the prompt

## Implementation Details
These changes reinforce the separation of concerns: PM-Alpha handles planning and task decomposition exclusively through documentation updates, while Coder-Bot handles all code implementation. The explicit boundaries prevent scope creep and ensure PM-Alpha remains a coordination layer rather than a code-generating agent.

https://claude.ai/code/session_01AeU4eQFGK6Smjr7KDaSxLy