### PR TITLE
docs: Record waiting state in project log

### DIFF
--- a/docs/PROJECT_LOG.md
+++ b/docs/PROJECT_LOG.md
@@ -7,3 +7,4 @@
 [2026-03-02] (Coder-Bot) 開始執行 T-005：在 src/App.tsx 引入 migrateSaveData 函式，並於 useState 初始化讀取 localStorage 存檔時，對解析出的 JSON 資料套用 migrateSaveData 進行舊格式遷移
 [2026-03-02] (Coder-Bot) 完成 T-005 [Done]：在 App.tsx 引入並套用 migrateSaveData 進行舊格式遷移
 - [2026-03-02] (PM-Alpha) 指派 T-006（關聯 設計任務T-080 的第 4 步）給 Coder-Bot。
+- [2026-03-02] (PM-Alpha) 紀錄等待狀態，不新增任務。


### PR DESCRIPTION
According to the rules (Situation C), if there is a `waiting` task in the `docs/TASK_LIST.md`, PM-Alpha should record a waiting state in the `docs/PROJECT_LOG.md` without adding a new task. The `T-006` task was found to be waiting.

---
*PR created automatically by Jules for task [6175298374525837944](https://jules.google.com/task/6175298374525837944) started by @ochowei*