### PR TITLE
docs: add T-009 atomic task for save success animation

### DIFF
--- a/docs/PROJECT_LOG.md
+++ b/docs/PROJECT_LOG.md
@@ -22,3 +22,4 @@
 - [2026-03-03] (PM-Alpha) 指派 T-008（關聯 設計任務T-080 的第 6 步）給 Coder-Bot。
 - [2026-03-03] (Coder-Bot) 開始執行 T-008：在 GameState 與 App.tsx 新增手動存檔按鈕、lastSaveTime 與上次存檔時間顯示
 - [2026-03-03] (Coder-Bot) 完成 T-008 [Done]：於 Header 新增手動存檔按鈕並顯示上次存檔時間
+- [2026-03-03] (PM-Alpha) 指派 T-009（關聯 設計任務T-080 的第 7 步）給 Coder-Bot。

--- a/docs/TASK_LIST.md
+++ b/docs/TASK_LIST.md
@@ -7,3 +7,4 @@ T-005,G-001,T-080,在 src/App.tsx 引入 migrateSaveData 函式，並於 useStat
 T-006,G-001,T-080,在 src/utils/save.ts 新增 isValidSaveData 函式，並實作存檔完整性驗證（檢查必填欄位如 qi、realm、buildings 等），並將其匯出,Coder-Bot,done
 T-007,G-001,T-080,在 src/App.tsx 的存檔讀取初始化流程中串接 isValidSaveData 驗證；當驗證失敗時套用 INITIAL_STATE 作為 fallback 並避免使用損壞存檔，維持既有命名與狀態欄位風格,Coder-Bot,done
 T-008,G-001,T-080,「手動存檔按鈕 UI」：(1) 在 src/types/game.ts 的 GameState interface 新增 lastSaveTime: number 欄位；(2) 在 src/App.tsx 的 INITIAL_STATE 加入 lastSaveTime: 0 預設值；(3) 在 src/App.tsx UI 適當位置（參考現有 Header 區塊與 lucide-react 圖示用法）新增一個手動存檔按鈕，點擊時將當前 gameState 序列化後寫入 localStorage key 'xianxia_save' 並更新 lastSaveTime 為 Date.now()；(4) 按鈕下方顯示上次存檔時間（格式：「上次存檔：剛剛」或「上次存檔：N 分鐘前」，使用與現有 formatNumber 相同的 helper 風格實作 formatSaveTime 函式）,Coder-Bot,done
+T-009,G-001,T-080,在 src/App.tsx 新增手動存檔成功提示動畫：點擊手動存檔按鈕後以現有 Header 區塊風格顯示短暫成功訊息（例如「存檔成功」），需於固定時間自動淡出並避免影響既有自動存檔流程與 lastSaveTime 顯示,Coder-Bot,waiting


### PR DESCRIPTION
### Motivation
- Queue the next atomic step for design task `T-080` because steps 1–6 are completed and there were no other in-progress atomic tasks to execute.

### Description
- Added a new waiting atomic task `T-009` to `docs/TASK_LIST.md` (G-001, relates to `T-080` step 7) describing the manual save success animation to implement, and recorded the PM assignment in `docs/PROJECT_LOG.md`; no changes were made under `src/`.

### Testing
- Verified repository checks with `git diff --check` and `git status --short`, both returned no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a694d26308832b8bac9bbc53d51fdd)