### PR TITLE
feat(ui): add manual save success feedback animation

### DIFF
--- a/docs/PROJECT_LOG.md
+++ b/docs/PROJECT_LOG.md
@@ -23,3 +23,5 @@
 - [2026-03-03] (Coder-Bot) 開始執行 T-008：在 GameState 與 App.tsx 新增手動存檔按鈕、lastSaveTime 與上次存檔時間顯示
 - [2026-03-03] (Coder-Bot) 完成 T-008 [Done]：於 Header 新增手動存檔按鈕並顯示上次存檔時間
 - [2026-03-03] (PM-Alpha) 指派 T-009（關聯 設計任務T-080 的第 7 步）給 Coder-Bot。
+- [2026-03-03] (Coder-Bot) 開始執行 T-009：在 App.tsx 新增手動存檔成功提示動畫並自動淡出
+- [2026-03-03] (Coder-Bot) 完成 T-009 [Done]：在 Header 新增手動存檔成功提示並於固定時間自動淡出

--- a/docs/TASK_LIST.md
+++ b/docs/TASK_LIST.md
@@ -7,4 +7,4 @@ T-005,G-001,T-080,在 src/App.tsx 引入 migrateSaveData 函式，並於 useStat
 T-006,G-001,T-080,在 src/utils/save.ts 新增 isValidSaveData 函式，並實作存檔完整性驗證（檢查必填欄位如 qi、realm、buildings 等），並將其匯出,Coder-Bot,done
 T-007,G-001,T-080,在 src/App.tsx 的存檔讀取初始化流程中串接 isValidSaveData 驗證；當驗證失敗時套用 INITIAL_STATE 作為 fallback 並避免使用損壞存檔，維持既有命名與狀態欄位風格,Coder-Bot,done
 T-008,G-001,T-080,「手動存檔按鈕 UI」：(1) 在 src/types/game.ts 的 GameState interface 新增 lastSaveTime: number 欄位；(2) 在 src/App.tsx 的 INITIAL_STATE 加入 lastSaveTime: 0 預設值；(3) 在 src/App.tsx UI 適當位置（參考現有 Header 區塊與 lucide-react 圖示用法）新增一個手動存檔按鈕，點擊時將當前 gameState 序列化後寫入 localStorage key 'xianxia_save' 並更新 lastSaveTime 為 Date.now()；(4) 按鈕下方顯示上次存檔時間（格式：「上次存檔：剛剛」或「上次存檔：N 分鐘前」，使用與現有 formatNumber 相同的 helper 風格實作 formatSaveTime 函式）,Coder-Bot,done
-T-009,G-001,T-080,在 src/App.tsx 新增手動存檔成功提示動畫：點擊手動存檔按鈕後以現有 Header 區塊風格顯示短暫成功訊息（例如「存檔成功」），需於固定時間自動淡出並避免影響既有自動存檔流程與 lastSaveTime 顯示,Coder-Bot,waiting
+T-009,G-001,T-080,在 src/App.tsx 新增手動存檔成功提示動畫：點擊手動存檔按鈕後以現有 Header 區塊風格顯示短暫成功訊息（例如「存檔成功」），需於固定時間自動淡出並避免影響既有自動存檔流程與 lastSaveTime 顯示,Coder-Bot,done

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,7 +114,9 @@ export default function App() {
   const stateRef = useRef(gameState);
   const lastTickRef = useRef(performance.now());
   const saveTimerRef = useRef(0);
+  const saveSuccessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const logsEndRef = useRef<HTMLDivElement>(null);
+  const [isSaveSuccessVisible, setIsSaveSuccessVisible] = useState(false);
 
   // 同步 React state 到 ref
   useEffect(() => {
@@ -125,6 +127,14 @@ export default function App() {
   useEffect(() => {
     logsEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [gameState.logs]);
+
+  useEffect(() => {
+    return () => {
+      if (saveSuccessTimerRef.current) {
+        clearTimeout(saveSuccessTimerRef.current);
+      }
+    };
+  }, []);
 
   // --- Game Loop ---
   useEffect(() => {
@@ -239,6 +249,14 @@ export default function App() {
       stateRef.current = savedState;
       return savedState;
     });
+
+    setIsSaveSuccessVisible(true);
+    if (saveSuccessTimerRef.current) {
+      clearTimeout(saveSuccessTimerRef.current);
+    }
+    saveSuccessTimerRef.current = setTimeout(() => {
+      setIsSaveSuccessVisible(false);
+    }, 1500);
   };
 
   const handleReset = () => {
@@ -279,6 +297,11 @@ export default function App() {
           >
             <Save className="w-4 h-4 text-amber-500" /> 手動存檔
           </button>
+          <div
+            className={`text-xs text-green-400 mt-2 transition-opacity duration-500 ${isSaveSuccessVisible ? 'opacity-100' : 'opacity-0'}`}
+          >
+            存檔成功
+          </div>
           <div className="text-xs text-zinc-500 mt-2">{formatSaveTime(gameState.lastSaveTime)}</div>
         </div>
       </header>


### PR DESCRIPTION
### Motivation
- Provide immediate user feedback when the manual save button is clicked so players see a brief confirmation without interfering with existing auto-save behavior.

### Description
- Added a transient success message shown in the header save card by introducing `isSaveSuccessVisible` state and rendering a fading `存檔成功` message in `src/App.tsx`.
- Implemented a `saveSuccessTimerRef` timeout to auto-hide the message after a fixed delay and added an unmount cleanup `useEffect` to clear pending timers.
- Triggered the success message from `handleManualSave` while preserving the existing `lastSaveTime` update and automatic save flow in `src/App.tsx`.
- Updated task tracking files `docs/TASK_LIST.md` and `docs/PROJECT_LOG.md` to mark `T-009` as done and record start/completion log entries.

### Testing
- Ran TypeScript lint with `npm run lint` and the build with `npm run build`, both completed successfully.
- Started the dev server with `npm run dev` to validate runtime and used a Playwright script to click the manual save button and capture a screenshot, which succeeded and produced an artifact.
- Verified the repository commit containing changes to `src/App.tsx`, `docs/TASK_LIST.md`, and `docs/PROJECT_LOG.md` was created with message `feat(ui): add manual save success toast with auto fade` and task linkage `[Done T-009] 關聯設計任務 T-080（第 7 步）`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6957bf630832b8264eb3af5c9d1ee)